### PR TITLE
Enhancement for Transformers

### DIFF
--- a/config/transformer.php
+++ b/config/transformer.php
@@ -23,7 +23,7 @@ return [
     */
     'adapter' => function() {
         // Instantiate Fractal Manager
-        $manager = new League\Fractal\Manager;
+        $manager = new Nodes\Api\Transformer\Manager;
 
         // Set serializer
         $serializer = prepare_config_instance(config('nodes.api.transformer.fractal.serializer.class'));
@@ -35,9 +35,9 @@ return [
         // Instantiate transformer
         return new $adapter(
             $manager,
-            config('nodes.api.transformer.includeKey', 'include'),
-            config('nodes.api.transformer.incldueSeparator', ','),
-            config('nodes.api.transformer.eagerLoad', true)
+            config('nodes.api.transformer.fractal.includeKey', 'include'),
+            config('nodes.api.transformer.fractal.incldueSeparator', ','),
+            config('nodes.api.transformer.fractal.eagerLoad', true)
         );
     },
 

--- a/src/Transformer/Manager.php
+++ b/src/Transformer/Manager.php
@@ -1,0 +1,42 @@
+<?php
+namespace Nodes\Api\Transformer;
+
+use League\Fractal\Resource\ResourceInterface;
+use League\Fractal\Scope as FractalScope;
+use League\Fractal\Manager as FractalManager;
+
+/**
+ * Class Manager
+ *
+ * @package Nodes\Api\Transformer
+ */
+class Manager extends FractalManager
+{
+    /**
+     * Main method to kick this all off.
+     * Make a resource then pass it over, and use toArray()
+     *
+     * @author Morten Rugaard <moru@nodes.dk>
+     *
+     * @access public
+     * @param  \League\Fractal\Resource\ResourceInterface $resource
+     * @param  string                                     $scopeIdentifier
+     * @param  \League\Fractal\Scope                      $parentScopeInstance
+     * @return \Nodes\Api\Transformer\Scope
+     */
+    public function createData(ResourceInterface $resource, $scopeIdentifier = null, FractalScope $parentScopeInstance = null)
+    {
+        $scopeInstance = new Scope($this, $resource, $scopeIdentifier);
+
+        // Update scope history
+        if ($parentScopeInstance !== null) {
+            // This will be the new children list of parents (parents parents, plus the parent)
+            $scopeArray = $parentScopeInstance->getParentScopes();
+            $scopeArray[] = $parentScopeInstance->getScopeIdentifier();
+
+            $scopeInstance->setParentScopes($scopeArray);
+        }
+
+        return $scopeInstance;
+    }
+}

--- a/src/Transformer/Resources/Content.php
+++ b/src/Transformer/Resources/Content.php
@@ -1,0 +1,14 @@
+<?php
+namespace Nodes\Api\Transformer\Resources;
+
+use League\Fractal\Resource\ResourceAbstract;
+
+/**
+ * Class Content
+ *
+ * @package Nodes\Api\Transformer\Resources
+ */
+class Content extends ResourceAbstract
+{
+
+}

--- a/src/Transformer/Scope.php
+++ b/src/Transformer/Scope.php
@@ -1,0 +1,105 @@
+<?php
+namespace Nodes\Api\Transformer;
+
+use InvalidArgumentException;
+use League\Fractal\Resource\Collection as FractalCollection;
+use League\Fractal\Resource\Item as FractalItem;
+use League\Fractal\Resource\NullResource as FractalNullResource;
+use League\Fractal\Scope as FractalScope;
+use League\Fractal\Serializer\SerializerAbstract as FractalSerializerAbstract;
+use League\Fractal\TransformerAbstract as FractalTransformerAbstract;
+use Nodes\Api\Transformer\Resources\Content as NodesResourceContent;
+use Nodes\Api\Transformer\TransformerAbstract as NodesTransformerAbstract;
+
+/**
+ * Class Scope
+ *
+ * @package Nodes\Api\Transformers
+ */
+class Scope extends FractalScope
+{
+    /**
+     * Determine if a transformer has any available includes
+     *
+     * @author Morten Rugaard <moru@nodes.dk>
+     *
+     * @access protected
+     * @param  \Nodes\Api\Transformer\TransformerAbstract|\League\Fractal\TransformerAbstract|callable $transformer
+     * @return boolean
+     */
+    protected function transformerHasIncludes($transformer)
+    {
+        if (!$transformer instanceof NodesTransformerAbstract &&
+            !$transformer instanceof FractalTransformerAbstract) {
+            return false;
+        }
+
+        $defaultIncludes = $transformer->getDefaultIncludes();
+        $availableIncludes = $transformer->getAvailableIncludes();
+
+        return !empty($defaultIncludes) || !empty($availableIncludes);
+    }
+
+    /**
+     * Serialize a resource
+     *
+     * @author Morten Rugaard <moru@nodes.dk>
+     *
+     * @access public
+     * @param  \League\Fractal\Serializer\SerializerAbstract $serializer
+     * @param  mixed                                         $data
+     * @return array
+     */
+    protected function serializeResource(FractalSerializerAbstract $serializer, $data)
+    {
+        $resourceKey = $this->resource->getResourceKey();
+
+        if ($this->resource instanceof FractalCollection) {
+            return $serializer->collection($resourceKey, $data);
+        } elseif ($this->resource instanceof FractalItem) {
+            return $serializer->item($resourceKey, $data);
+        } elseif ($this->resource instanceof NodesResourceContent) {
+            return (!empty($resourceKey)) ? [$resourceKey => $data] : $data;
+        }
+
+        return $serializer->null();
+    }
+
+    /**
+     * Execute the resources transformer and return the data and included data
+     *
+     * @author Morten Rugaard <moru@nodes.dk>
+     *
+     * @access protected
+     * @return array
+     * @throws \InvalidArgumentException
+     */
+    protected function executeResourceTransformers()
+    {
+        $transformer = $this->resource->getTransformer();
+        $data = $this->resource->getData();
+
+        $transformedData = $includedData = [];
+
+        if ($this->resource instanceof FractalItem) {
+            list($transformedData, $includedData[]) = $this->fireTransformer($transformer, $data);
+        } elseif ($this->resource instanceof FractalCollection) {
+            foreach ($data as $value) {
+                list($transformedData[], $includedData[]) = $this->fireTransformer($transformer, $value);
+            }
+        } elseif ($this->resource instanceof FractalNullResource) {
+            $transformedData = null;
+            $includedData = [];
+        } elseif ($this->resource instanceof NodesResourceContent) {
+            $transformedData = (array) $data;
+            $includedData = [];
+        } else {
+            throw new InvalidArgumentException(
+                'Argument $resource should be an instance of League\Fractal\Resource\Item'
+                .' or League\Fractal\Resource\Collection'
+            );
+        }
+
+        return [$transformedData, $includedData];
+    }
+}

--- a/src/Transformer/TransformerAbstract.php
+++ b/src/Transformer/TransformerAbstract.php
@@ -1,29 +1,90 @@
 <?php
 namespace Nodes\Api\Transformer;
 
-use League\Fractal\Scope as FractalScope;
-use League\Fractal\TransformerAbstract as FractalTransformerAbstract;
 use League\Fractal\Resource\Collection as FractalCollection;
 use League\Fractal\Resource\NullResource as FractalNullResource;
 use League\Fractal\Resource\Item as FractalItem;
+use League\Fractal\Resource\ResourceAbstract as FractalResourceAbstract;
+use Nodes\Api\Transformer\Resources\Content as NodesResourceContent;
 
 /**
  * Class TransformerAbstract
  *
  * @package Nodes\Api\Transformer
  */
-abstract class TransformerAbstract extends FractalTransformerAbstract
+abstract class TransformerAbstract
 {
+    /**
+     * Resources that can be included if requested
+     *
+     * @var array
+     */
+    protected $availableIncludes = [];
+
+    /**
+     * Include resources without needing it to be requested
+     *
+     * @var array
+     */
+    protected $defaultIncludes = [];
+
+    /**
+     * The transformer should know about the current scope,
+     * so we can fetch relevant params
+     *
+     * @var \Nodes\Api\Transformer\Scope
+     */
+    protected $currentScope;
+
+    /**
+     * Getter for availableIncludes
+     *
+     * @author Morten Rugaard <moru@nodes.dk>
+     *
+     * @access public
+     * @return array
+     */
+    public function getAvailableIncludes()
+    {
+        return $this->availableIncludes;
+    }
+
+    /**
+     * Getter for defaultIncludes
+     *
+     * @author Morten Rugaard <moru@nodes.dk>
+     *
+     * @access public
+     * @return array
+     */
+    public function getDefaultIncludes()
+    {
+        return $this->defaultIncludes;
+    }
+
+    /**
+     * Getter for currentScope
+     *
+     * @author Morten Rugaard <moru@nodes.dk>
+     *
+     * @access public
+     * @return \Nodes\Api\Transformer\Scope
+     */
+    public function getCurrentScope()
+    {
+        return $this->currentScope;
+    }
+
     /**
      * Figure out which includes we need
      *
      * @author Morten Rugaard <moru@nodes.dk>
      *
      * @access private
-     * @param  \League\Fractal\Scope $scope
+     * @param  \Nodes\Api\Transformer\Scope $scope
      * @return array
      */
-    private function figureOutWhichIncludes(FractalScope $scope)
+    private function figureOutWhichIncludes(Scope $scope)
     {
         $includes = $this->getDefaultIncludes();
         foreach ($this->getAvailableIncludes() as $include) {
@@ -42,11 +103,11 @@ abstract class TransformerAbstract extends FractalTransformerAbstract
      * @author Morten Rugaard <moru@nodes.dk>
      *
      * @access public
-     * @param  \League\Fractal\Scope $scope
-     * @param  mixed                 $data
+     * @param  \Nodes\Api\Transformer\Scope $scope
+     * @param  mixed                        $data
      * @return array
      */
-    public function processIncludedResources(FractalScope $scope, $data)
+    public function processIncludedResources(Scope $scope, $data)
     {
         $includedData = [];
 
@@ -70,25 +131,103 @@ abstract class TransformerAbstract extends FractalTransformerAbstract
      * @author Morten Rugaard <moru@nodes.dk>
      *
      * @access private
-     * @param  \League\Fractal\Scope $scope
-     * @param  mixed  $data
-     * @param  array  $includedData
-     * @param  string $include
+     * @param  \Nodes\Api\Transformer\Scope $scope
+     * @param  mixed                        $data
+     * @param  array                        $includedData
+     * @param  string                       $include
      * @return array
      */
-    private function includeResourceIfAvailable(
-        FractalScope $scope,
-        $data,
-        $includedData,
-        $include
-    ) {
+    private function includeResourceIfAvailable(Scope $scope, $data, $includedData, $include) {
         if ($resource = $this->callIncludeMethod($scope, $include, $data)) {
             $childScope = $scope->embedChildScope($include, $resource);
-
             $includedData[$include] = (!$childScope->getResource() instanceof FractalNullResource) ? $childScope->toArray() : null;
         }
 
         return $includedData;
+    }
+
+    /**
+     * Call Include Method
+     *
+     * @author Morten Rugaard <moru@nodes.dk>
+     *
+     * @access protected
+     * @param  Scope  $scope
+     * @param  string $includeName
+     * @param  mixed  $data
+     * @return \League\Fractal\Resource\ResourceInterface
+     * @throws \Exception
+     */
+    protected function callIncludeMethod(Scope $scope, $includeName, $data)
+    {
+        $scopeIdentifier = $scope->getIdentifier($includeName);
+        $params = $scope->getManager()->getIncludeParams($scopeIdentifier);
+
+        // Check if the method name actually exists
+        $methodName = 'include'.str_replace(' ', '', ucwords(str_replace('_', ' ', str_replace('-', ' ', $includeName))));
+
+        $resource = call_user_func([$this, $methodName], $data, $params);
+
+        if ($resource === null) {
+            return false;
+        }
+
+        if (!$resource instanceof FractalResourceAbstract) {
+            throw new \Exception(sprintf(
+                'Invalid return value from %s::%s(). Expected %s, received %s.',
+                __CLASS__,
+                $methodName,
+                'League\Fractal\Resource\ResourceAbstract',
+                gettype($resource)
+            ));
+        }
+
+        return $resource;
+    }
+
+    /**
+     * Setter for availableIncludes
+     *
+     * @author Morten Rugaard <moru@nodes.dk>
+     *
+     * @access public
+     * @param  array $availableIncludes
+     * @return $this
+     */
+    public function setAvailableIncludes($availableIncludes)
+    {
+        $this->availableIncludes = $availableIncludes;
+        return $this;
+    }
+
+    /**
+     * Setter for defaultIncludes
+     *
+     * @author Morten Rugaard <moru@nodes.dk>
+     *
+     * @access public
+     * @param  array $defaultIncludes
+     * @return $this
+     */
+    public function setDefaultIncludes($defaultIncludes)
+    {
+        $this->defaultIncludes = $defaultIncludes;
+        return $this;
+    }
+
+    /**
+     * Setter for currentScope
+     *
+     * @author Morten Rugaard <moru@nodes.dk>
+     *
+     * @access public
+     * @param  \Nodes\Api\Transformer\Scope $currentScope
+     * @return $this
+     */
+    public function setCurrentScope($currentScope)
+    {
+        $this->currentScope = $currentScope;
+        return $this;
     }
 
     /**
@@ -98,7 +237,7 @@ abstract class TransformerAbstract extends FractalTransformerAbstract
      *
      * @access protected
      * @param  mixed                                              $data
-     * @param  \Nodes\Api\Transformer\TransformerAbstract|callable $transformer
+     * @param  \Nodes\Api\Transformer\TransformerAbsract|callable $transformer
      * @param  string                                             $resourceKey
      * @return \League\Fractal\Resource\Item|\League\Fractal\Resource\NullResource
      */
@@ -118,7 +257,7 @@ abstract class TransformerAbstract extends FractalTransformerAbstract
      *
      * @access protected
      * @param  mixed                                              $data
-     * @param  \Nodes\Api\Transformer\TransformerAbstract|callable $transformer
+     * @param  \Nodes\Api\Transformer\TransformerAbsract|callable $transformer
      * @param  string                                             $resourceKey
      * @return \League\Fractal\Resource\Collection|\League\Fractal\Resource\NullResource
      */
@@ -129,5 +268,24 @@ abstract class TransformerAbstract extends FractalTransformerAbstract
         }
 
         return new FractalCollection($data, $transformer, $resourceKey);
+    }
+
+    /**
+     * Create a new content (array) resource object
+     *
+     * @author Morten Rugaard <moru@nodes.dk>
+     *
+     * @access public
+     * @param  array $data
+     * @param  string $resourceKey
+     * @return \Nodes\Api\Transformer\Resources\Content|\League\Fractal\Resource\NullResource
+     */
+    protected function content(array $data, $resourceKey = null)
+    {
+        if (empty($data)) {
+            return new FractalNullResource;
+        }
+
+        return new NodesResourceContent($data, null, $resourceKey);
     }
 }


### PR DESCRIPTION
#### Changes
- Fixed bug in `transformer.php` config file
- Added more flexibility to `Manager` and `Scope` for easier extension
- Added support for plain arrays in transformer includes (see more details below)
#### Plain arrays in relations

Before when you added a default/available include to your transformer, you always had to create another transformer for it, since Fractal required a `ResourceAbstract` instance.

This pull request adds support for plain arrays, so you don't need to create a new Transformer class - which basically just returns a plain array - just to get around the Fractal required `ResourceAbstract` instance.

```
public function includeCounts(User $data)
{
     return $this->content([
           'posts_count' => $data->posts_count,
           'comments_count' => $data->comments_count,
     ]);
}
```
