### PR TITLE
Fix bug in API response

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -55,7 +55,7 @@ class Response extends DingoResponse
     }
 
     /**
-     * Make an API response from an existing Illuminate response
+     * Make an API response from an existing response object
      *
      * @author Morten Rugaard <moru@nodes.dk>
      *
@@ -65,7 +65,11 @@ class Response extends DingoResponse
      */
     public static function makeFromExisting(IlluminateResponse $old)
     {
-        $new = static::create($old->getOriginalContent(), $old->getStatusCodeAndMessage());
+        // Support for custom status code and message
+        $statusCode = ($old instanceof Response) ? $old->getStatusCodeAndMessage() : $old->getStatusCode();
+
+        // Generate API response from response object
+        $new = static::create($old->getOriginalContent(), $statusCode);
         $new->headers = $old->headers;
         return $new;
     }


### PR DESCRIPTION
- Fixed bug in `Nodes\Api\Http\Response` where creating an API response from an Illuminate Response object would break in an undefined method.

Would occur everytime a OPTIONS request would be send to an API endpoint. I.e. in form of a CORS request.
