### PR TITLE
throw any exception in testing environment

### DIFF
--- a/config/errors.php
+++ b/config/errors.php
@@ -29,6 +29,19 @@ return [
         'code' => ':code',
         'errors' => ':errors',
         'debug' => ':debug',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Throw exception in these environments
+    |--------------------------------------------------------------------------
+    |
+    | For some cases, like unit testing. It can be useful to not render
+    | exception as json
+    |
+    */
+    'throwOnEnvironment' => [
+       'testing'
     ]
 
 ];

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -41,10 +41,6 @@ class Handler extends DingoExceptionHandler
      */
     public function report(Exception $e)
     {
-        // If we are testing, just throw the exception.
-        if (App::environment() == 'testing') {
-            throw $e;
-        }
         try {
             if ($e instanceof NodesException && $e->getReport()) {
                 app('nodes.bugsnag')->notifyException($e, $e->getMeta(), $e->getSeverity());
@@ -62,13 +58,20 @@ class Handler extends DingoExceptionHandler
      * Handle an exception if it has an existing handler
      *
      * @author Morten Rugaard <moru@nodes.dk>
+     * @author Casper Rasmussen <cr@nodes.dk>
      *
      * @access public
      * @param \Exception $exception
      * @return \Illuminate\Http\Response
+     * @throws \Exception
      */
     public function handle(Exception $exception)
     {
+        // If we are in configured environments, just throw the exception. Useful for unit testing
+        if (in_array(app()->environment(), config('nodes.api.errors.throwOnEnvironment', []))) {
+            throw $exception;
+        }
+
         $this->report($exception);
 
         foreach ($this->handlers as $hint => $handler) {

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -1,6 +1,7 @@
 <?php
 namespace Nodes\Api\Exceptions;
 
+use App;
 use Exception;
 use Nodes\Api\Http\Response;
 use Illuminate\Support\Facades\Log;
@@ -35,11 +36,15 @@ class Handler extends DingoExceptionHandler
      * @author Morten Rugaard <moru@nodes.dk>
      *
      * @access public
-     * @param  \Exception $e
-     * @return void
+     * @param  Exception $e
+     * @throws Exception
      */
     public function report(Exception $e)
     {
+        // If we are testing, just throw the exception.
+        if (App::environment() == 'testing') {
+            throw $e;
+        }
         try {
             if ($e instanceof NodesException && $e->getReport()) {
                 app('nodes.bugsnag')->notifyException($e, $e->getMeta(), $e->getSeverity());


### PR DESCRIPTION
This is needed by phpunit, without this change exceptions thrown by laravel while testing controllers are not visible in cli
