### PR TITLE
Fix bug where composer file would contain escaped data

### DIFF
--- a/src/Console/Commands/Scaffolding.php
+++ b/src/Console/Commands/Scaffolding.php
@@ -580,6 +580,6 @@ class Scaffolding extends Command
         $composerFile->autoload->classmap[] = 'project';
 
         // Save changes to composer file
-        file_put_contents($composerFilePath, json_encode($composerFile, JSON_PRETTY_PRINT));
+        file_put_contents($composerFilePath, json_encode($composerFile, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
 }


### PR DESCRIPTION
- Fixed bug where `composer.json` would be "corrupted" by escaped slashes.
