### PR TITLE
Api routing helper docs

### DIFF
--- a/src/Routing/Helpers.php
+++ b/src/Routing/Helpers.php
@@ -12,6 +12,7 @@ use Dingo\Api\Routing\Helpers as DingoRoutingHelpers;
  * @property \Illuminate\Database\Eloquent\Model $user
  * @property \Nodes\Api\Auth\Auth                $auth
  * @property \Nodes\Api\Http\Response\Factory    $response
+ * @method Response item() item($item, $transformer, array $parameters = [], Closure $after = null) Bind an item to a transformer and start building a response
  */
 trait Helpers
 {


### PR DESCRIPTION
Just a missing documentation that'll help PHPStorm create correct phpdoc of api controllers
