### PR TITLE
convert ModelNotFoundException into 404 response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require": {
         "nodes/dingo": "~1.0",
         "nodes/core": "~1.0",
-        "nodes/cache": "~1.0"
+        "nodes/cache": "~1.0",
+        "nodes/database": "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Auth/Providers/MasterToken.php
+++ b/src/Auth/Providers/MasterToken.php
@@ -79,9 +79,9 @@ class MasterToken implements DingoAuthContract
 
         // Fields used to retrieve user associated with master token
         $this->tokenColumns = config('nodes.auth.masterToken.user', [
-            'column'   => 'master',
+            'column' => 'master',
             'operator' => '=',
-            'value'    => 1,
+            'value' => 1,
         ]);
 
         return $this;

--- a/src/Auth/Providers/UserToken.php
+++ b/src/Auth/Providers/UserToken.php
@@ -81,8 +81,8 @@ class UserToken implements DingoAuthContract
         // Set token columns used in condition
         $columns = config('nodes.api.auth.userToken.columns', [
             'user_id' => 'user_id',
-            'token'   => 'token',
-            'expire'  => 'expire',
+            'token' => 'token',
+            'expire' => 'expire',
         ]);
 
         // Prepend token table name to token columns

--- a/src/Auth/ResetPassword/ResetPasswordController.php
+++ b/src/Auth/ResetPassword/ResetPasswordController.php
@@ -149,10 +149,7 @@ class ResetPasswordController extends IlluminateController
         }
 
         // Generate token and send e-mail
-        $status = $this->resetPasswordRepository->sendResetPasswordEmail(['email' => $email]);
-        if (empty($status)) {
-            throw new Exception('Could not send reset password e-mail', 500);
-        }
+        $this->resetPasswordRepository->sendResetPasswordEmail(['email' => $email]);
 
         return $this->response->content([
             'email' => 'sent',

--- a/src/Auth/ResetPassword/ResetPasswordRepository.php
+++ b/src/Auth/ResetPassword/ResetPasswordRepository.php
@@ -78,14 +78,13 @@ class ResetPasswordRepository extends NodesRepository
      * @author Morten Rugaard <moru@nodes.dk>
      *
      * @param  array $conditions WHERE conditions to locate user. Format: ['column' => 'value']
-     * @return bool
      * @throws \Nodes\Api\Auth\Exceptions\ResetPasswordNoUserException
      */
     public function sendResetPasswordEmail(array $conditions)
     {
         // Validate conditions
         if (empty($conditions)) {
-            return false;
+            throw new ResetPasswordNoUserException('Conditions can\'t be empty');
         }
 
         // Add conditions to query builder
@@ -106,7 +105,7 @@ class ResetPasswordRepository extends NodesRepository
         $domain = env('NODES_ENV', false) ? sprintf('https://%s.%s', env('APP_NAME'), env('APP_DOMAIN')) : config('app.url');
 
         // Send e-mail with instructions on how to reset password
-        $status = (bool) Mail::send([
+        Mail::send([
             'html' => config('nodes.api.reset-password.views.html', 'nodes.api::reset-password.emails.html'),
             'text' => config('nodes.api.reset-password.views.text', 'nodes.api::reset-password.emails.text'),
         ], [
@@ -120,8 +119,6 @@ class ResetPasswordRepository extends NodesRepository
                     ->from(config('nodes.api.reset-password.from.email', 'no-reply@nodes.dk'), config('nodes.api.reset-password.from.name', 'Nodes'))
                     ->subject(config('nodes.api.reset-password.subject', 'Reset password request'));
         });
-
-        return $status;
     }
 
     /**

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -4,6 +4,7 @@ namespace Nodes\Api\Exceptions;
 
 use App;
 use Exception;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Nodes\Api\Http\Response;
 use Illuminate\Support\Facades\Log;
 use Dingo\Api\Contract\Debug\MessageBagErrors;
@@ -64,6 +65,11 @@ class Handler extends DingoExceptionHandler
      */
     public function handle(Exception $exception)
     {
+        // ModelNotFoundException is thrown when model bind to route does not exist
+        if ($exception instanceof ModelNotFoundException) {
+            abort(404);
+        }
+
         // If we are in configured environments, just throw the exception. Useful for unit testing
         if (in_array(app()->environment(), config('nodes.api.errors.throwOnEnvironment', []))) {
             throw $exception;

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Nodes\Api\Http\Response;
 use Illuminate\Support\Facades\Log;
 use Dingo\Api\Contract\Debug\MessageBagErrors;
+use Nodes\Database\Exceptions\EntityNotFoundException;
 use Nodes\Exceptions\Exception as NodesException;
 use Dingo\Api\Exception\Handler as DingoExceptionHandler;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
@@ -67,7 +68,7 @@ class Handler extends DingoExceptionHandler
     {
         // ModelNotFoundException is thrown when model bind to route does not exist
         if ($exception instanceof ModelNotFoundException) {
-            abort(404);
+            throw new EntityNotFoundException($exception->getMessage());
         }
 
         // If we are in configured environments, just throw the exception. Useful for unit testing

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -138,7 +138,7 @@ class Handler extends DingoExceptionHandler
         // Base replacements
         $replacements = [
             ':message' => $message,
-            ':code'    => $exception->getCode(),
+            ':code' => $exception->getCode(),
         ];
 
         // If exception contains a message bag of errors
@@ -153,8 +153,8 @@ class Handler extends DingoExceptionHandler
         if ($this->runningInDebugMode()) {
             $replacements[':debug'] = [
                 'class' => get_class($exception),
-                'file'  => $exception->getFile(),
-                'line'  => $exception->getLine(),
+                'file' => $exception->getFile(),
+                'line' => $exception->getLine(),
                 'trace' => explode("\n", $exception->getTraceAsString()),
             ];
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -25,8 +25,6 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     public function boot()
     {
-        parent::boot();
-
         // Set response static instances
         $this->setResponseStaticInstances();
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -92,15 +92,15 @@ class ServiceProvider extends IlluminateServiceProvider
     {
         // Config files
         $this->publishes([
-            __DIR__.'/../config/auth.php'                 => config_path('nodes/api/auth.php'),
-            __DIR__.'/../config/email-verification.php'   => config_path('nodes/api/email-verification.php'),
-            __DIR__.'/../config/errors.php'               => config_path('nodes/api/errors.php'),
-            __DIR__.'/../config/middleware.php'           => config_path('nodes/api/middleware.php'),
-            __DIR__.'/../config/reset-password.php'       => config_path('nodes/api/reset-password.php'),
-            __DIR__.'/../config/response.php'             => config_path('nodes/api/response.php'),
-            __DIR__.'/../config/settings.php'             => config_path('nodes/api/settings.php'),
-            __DIR__.'/../config/throttling.php'           => config_path('nodes/api/throttling.php'),
-            __DIR__.'/../config/transformer.php'          => config_path('nodes/api/transformer.php'),
+            __DIR__.'/../config/auth.php' => config_path('nodes/api/auth.php'),
+            __DIR__.'/../config/email-verification.php' => config_path('nodes/api/email-verification.php'),
+            __DIR__.'/../config/errors.php' => config_path('nodes/api/errors.php'),
+            __DIR__.'/../config/middleware.php' => config_path('nodes/api/middleware.php'),
+            __DIR__.'/../config/reset-password.php' => config_path('nodes/api/reset-password.php'),
+            __DIR__.'/../config/response.php' => config_path('nodes/api/response.php'),
+            __DIR__.'/../config/settings.php' => config_path('nodes/api/settings.php'),
+            __DIR__.'/../config/throttling.php' => config_path('nodes/api/throttling.php'),
+            __DIR__.'/../config/transformer.php' => config_path('nodes/api/transformer.php'),
         ], 'config');
     }
 

--- a/src/Support/Traits/DingoServiceProvider.php
+++ b/src/Support/Traits/DingoServiceProvider.php
@@ -94,16 +94,16 @@ trait DingoServiceProvider
     {
         $aliases = [
             DingoHttpRequest::class => DingoContractHttpRequest::class,
-            'api.dispatcher'        => DingoDispatcher::class,
-            'api.http.validator'    => DingoHttpRequestValidator::class,
-            'api.http.response'     => DingoHttpResponseFactory::class,
-            'api.router'            => DingoRoutingRouter::class,
-            'api.router.adapter'    => DingoContractRoutingAdapter::class,
-            'api.auth'              => DingoAuth::class,
-            'api.limiting'          => DingoRateLimitHandler::class,
-            'api.transformer'       => DingoTransformerFactory::class,
-            'api.url'               => DingoRoutingUrlGenerator::class,
-            'api.exception'         => [
+            'api.dispatcher' => DingoDispatcher::class,
+            'api.http.validator' => DingoHttpRequestValidator::class,
+            'api.http.response' => DingoHttpResponseFactory::class,
+            'api.router' => DingoRoutingRouter::class,
+            'api.router.adapter' => DingoContractRoutingAdapter::class,
+            'api.auth' => DingoAuth::class,
+            'api.limiting' => DingoRateLimitHandler::class,
+            'api.transformer' => DingoTransformerFactory::class,
+            'api.url' => DingoRoutingUrlGenerator::class,
+            'api.exception' => [
                 DingoExceptionHandler::class,
                 DingoContractDebugExceptionHandler::class,
             ],


### PR DESCRIPTION
This is useful when we use model route - model binding https://laravel.com/docs/5.2/routing#route-model-binding

without the change api returns http 500

after change returns http 404
