### PR TITLE
Environments that requires the N-meta header are now read from config

### DIFF
--- a/src/Http/Middleware/Meta.php
+++ b/src/Http/Middleware/Meta.php
@@ -27,9 +27,12 @@ class Meta
      */
     public function handle($request, Closure $next)
     {
-        // Only accept requests with nodes meta
-        if (!app()->isLocal() && config('nodes.api.settings.strictNodesMetaHeader', false) && ! nodes_meta()) {
-            throw (new InvalidUserAgent(sprintf('Missing [%s] header', Parser::NODES_META_HEADER), 400))->setStatusCode(400);
+        // See if env require N-meta header
+        if (in_array(env('APP_ENV'), NodesMeta::getMetaEnvironments())) {
+            // Only accept requests with nodes meta
+            if (config('nodes.api.settings.strictNodesMetaHeader', false) && ! nodes_meta()) {
+                throw (new InvalidUserAgent(sprintf('Missing [%s] header', Parser::NODES_META_HEADER), 400))->setStatusCode(400);
+            }
         }
 
         return $next($request);

--- a/src/Tests/TestHelperTrait.php
+++ b/src/Tests/TestHelperTrait.php
@@ -60,7 +60,10 @@ trait TestHelperTrait
     public function callApi($method, $uri, array $data = [], array $headers = [])
     {
         return $this->json($method, $uri, $data,
-            array_merge(['Accept' => 'application/vnd.nodes.v'.$this->getApiVersion().'+json'], $headers));
+            array_merge([
+                'Accept' => 'application/vnd.nodes.v'.$this->getApiVersion().'+json',
+                'N-Meta' => 'testing;testing;1.0.0;1.0;unitTest'
+            ], $headers));
     }
 
     /**


### PR DESCRIPTION
- Additional environments and platforms are now read from config
- N-Meta header is now set pr. default in TestHelperTrait